### PR TITLE
Support forks of vscode in generated template

### DIFF
--- a/template/.vscode/tasks.json
+++ b/template/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Open Design",
       "type": "shell",
-      "command": "code -r ${workspaceFolder}/src/pages/design.ts",
+      "command": "${execPath} -r ${workspaceFolder}/src/pages/design.ts",
       "dependsOn": [
         "Split Editor"
       ]


### PR DESCRIPTION
I just replaced the word `code` with a variable containing the full path of vscode. This makes it so it will work out of the box for forks such as vscodium to work as well as regular vscode.

[see vscodes documentation for the predefined variable if interested](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables)

I tested out my change in a generated project I was trying to run in vscodium on linux. With the change it worked. I have not yet tested on windows with regular vscode, but I have a high degree of confidence this works exactly the same regardless of platform, based on the documentation.

Also, since I don't know where else to put this... Thank you so, so much for putting this together! I've been kinda at a loss at how to set up my coding environment to write jscad locally. having typescript support is also amazing.